### PR TITLE
Migrate grunt task from puma repository

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+    "rules": {
+        "curly": 2,
+        "eqeqeq": 2,
+        "no-caller": 2,
+        "no-empty": 0,
+        "no-new": 2,
+        "no-invalid-regexp": 2,
+        "no-control-regex": 2,
+        "no-regex-spaces": 2,
+        "no-undef": 2,
+        "strict": 2,
+        "no-unused-vars": [0, {
+            "vars": "all",
+            "args": "none"
+        }],
+        "semi": 2,
+        "no-new-object": 2,
+        "indent": [0, 4],
+        "valid-jsdoc": 2,
+        "no-trailing-spaces": 2,
+        "eol-last": 0,
+        "max-len": [1, 120]
+    },
+    "globals": {
+        "require": false,
+        "console": false,
+        "module": false
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/node_modules/
+npm-debug.log
+.idea
+.DS_Store
+tests/tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+node_js:
+  - 0.10
+  - 0.12
+  - 5.12
+  - 6.3
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+install:
+- npm install -g grunt-cli
+- npm install
+
+script:
+- grunt travis

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 - present UTN-LIS
+
+module.exports = function (grunt) {
+
+    'use strict';
+
+    require('load-grunt-tasks')(grunt);
+
+    // Project configuration.
+    grunt.initConfig({
+        // Configuration to be run (and then tested).
+        puma: {
+            default_options: {
+                options: {},
+                files: {
+                    'tests/tmp/result.js': [
+                        'tests/tmp/files/puma-test.js',
+                        'tests/tmp/files/puma-test2.js'
+                    ]
+                }
+            }
+        }
+    });
+
+    // Actually load this plugin's task(s).
+    grunt.loadTasks('tasks');
+
+    grunt.registerTask('default', ['puma']);
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,11 +19,22 @@ module.exports = function (grunt) {
                     ]
                 }
             }
+        },
+
+        eslint: {
+            target: [
+                'tasks/**/*.js',
+                'Gruntfile.js',
+                'tests/**/*.js',
+                '!tests/tmp/**/*.js',
+                '!tests/files/**/*.js'
+            ]
         }
     });
 
     // Actually load this plugin's task(s).
     grunt.loadTasks('tasks');
 
-    grunt.registerTask('default', ['puma']);
+    grunt.registerTask('travis', ['eslint']);
+    grunt.registerTask('default', ['eslint', 'puma']);
 };

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 pumascript
+Copyright (c) 2016 - present UTN-LIS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "keywords": [
         "grunt",
         "gruntplugin",
+        "grunt task",
+        "task",
         "optimization",
         "meta-programming",
         "metaprogramming",
@@ -33,8 +35,9 @@
         "pumascript": "^0.0.1"
     },
     "devDependencies": {
-        "grunt": "~0.4.5",
-        "load-grunt-tasks": "~3.1.0"
+        "grunt": "^0.4.5",
+        "load-grunt-tasks": "^3.1.0",
+        "grunt-eslint": "^18.0.0"
     },
     "scripts": {
         "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "grunt-puma",
+    "version": "0.0.1",
+    "description": "Grunt task that runs PumaScript on any JavaScript file",
+    "repository": {
+        "type": "git",
+        "url": "pumascript/grunt-puma.git"
+    },
+    "bugs": {
+        "url": "https://github.com/pumascript/grunt-puma/issues"
+    },
+    "author": {
+        "name": "PumaScript Team",
+        "url": "http://github.com/pumascript/grunt-puma"
+    },
+    "keywords": [
+        "grunt",
+        "gruntplugin",
+        "optimization",
+        "meta-programming",
+        "metaprogramming",
+        "ecma",
+        "ecmascript",
+        "javascript",
+        "puma"
+    ],
+    "main": "task/puma.js",
+    "engines": {
+        "node": ">= 0.8.0"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "pumascript": "*"
+    },
+    "devDependencies": {
+        "grunt": "~0.4.5",
+        "load-grunt-tasks": "~3.1.0"
+    },
+    "scripts": {
+        "test": "grunt test"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "pumascript": "*"
+        "pumascript": "^0.0.1"
     },
     "devDependencies": {
         "grunt": "~0.4.5",

--- a/tasks/puma.js
+++ b/tasks/puma.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 - present UTN-LIS
+// Copyright (c) 2016 - present UTN-LIS
 
 module.exports = function (grunt) {
     'use strict';

--- a/tasks/puma.js
+++ b/tasks/puma.js
@@ -1,20 +1,14 @@
 // Copyright (c) 2013 - present UTN-LIS
 
-/*
- * pumascript-grunt
- *
- * Copyright (c) 2015 UTN-LIS
- */
-
 module.exports = function (grunt) {
     'use strict';
 
     grunt.registerMultiTask('puma', 'Meta-programming features for Javascript', function () {
 
-        var puma = require('../dist/pumascript.js');
+        var puma = require('pumascript');
         // Iterate over all specified files in gruntfile.
         this.files.forEach(function (file) {
-            var res = "";
+            var res = '';
             file.src.filter(function(filepath){
                 //Concatenate them
                 res += grunt.file.read(filepath);
@@ -22,7 +16,7 @@ module.exports = function (grunt) {
 
             // Eval all the file concatenation
             var result = puma.evalPuma(res);
-            grunt.log.writeln("PumaScript run: SUCCESSFUL!");
+            grunt.log.writeln('PumaScript run: SUCCESSFUL!');
 
             // Write the destination file the result
             grunt.file.defaultEncoding = 'utf8';

--- a/tasks/puma.js
+++ b/tasks/puma.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
         // Iterate over all specified files in gruntfile.
         this.files.forEach(function (file) {
             var res = '';
-            file.src.filter(function(filepath){
+            file.src.filter(function (filepath) {
                 //Concatenate them
                 res += grunt.file.read(filepath);
             });
@@ -26,5 +26,4 @@ module.exports = function (grunt) {
             grunt.log.writeln('File with the result of PumaScript: "' + file.dest + '" was created.');
         });
     });
-
 };

--- a/tasks/puma.js
+++ b/tasks/puma.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2013 - present UTN-LIS
+
+/*
+ * pumascript-grunt
+ *
+ * Copyright (c) 2015 UTN-LIS
+ */
+
+module.exports = function (grunt) {
+    'use strict';
+
+    grunt.registerMultiTask('puma', 'Meta-programming features for Javascript', function () {
+
+        var puma = require('../dist/pumascript.js');
+        // Iterate over all specified files in gruntfile.
+        this.files.forEach(function (file) {
+            var res = "";
+            file.src.filter(function(filepath){
+                //Concatenate them
+                res += grunt.file.read(filepath);
+            });
+
+            // Eval all the file concatenation
+            var result = puma.evalPuma(res);
+            grunt.log.writeln("PumaScript run: SUCCESSFUL!");
+
+            // Write the destination file the result
+            grunt.file.defaultEncoding = 'utf8';
+            grunt.file.write(file.dest, result.output, grunt.file.defaultEncoding);
+
+            // Print a success message.
+            grunt.log.writeln('File with the result of PumaScript: "' + file.dest + '" was created.');
+        });
+    });
+
+};

--- a/tests/files/puma-test.js
+++ b/tests/files/puma-test.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 - present UTN-LIS
+
+var PUMA_FORCE_REWRITE = true;
+
+/* @meta */
+function $(valueExp) {
+    //Regular Expression for ID
+    var regex = /^#\b[a-zA-Z0-9_]+\b$/;
+    var copy = {};
+    var ast = {};
+
+    //Evaluation if not a literal
+    if (valueExp !== "Literal") {
+        copy = evalPumaAst(valueExp).value;
+    }
+
+    if (regex.test(copy) && PUMA_FORCE_REWRITE) {
+        return pumaAst($(getElementById($valueExp)));
+    } else if (regex.test(valueExp.value)) {
+        valueExp.value = valueExp.value.substring(1);
+        return pumaAst($(getElementById($valueExp)));
+    }
+    return null;
+}
+
+// Tests
+
+//Add a class in runtime so it does not need to re-write
+var t = " .pepe";
+
+//Context evaluation
+var a = function () {
+    var name = "puma";
+    $("#" + name + t);
+}();
+
+//Re-write because it returns a string
+var j = "ma";
+
+//Context evaluation
+var b = function () {
+    var name = "pu";
+    $("#" + name + j);
+}();

--- a/tests/files/puma-test2.js
+++ b/tests/files/puma-test2.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 - present UTN-LIS
+
+var PUMA_FORCE_REWRITE = true;
+
+/* @meta */
+function $(valueExp) {
+    //Regular Expression for ID
+    var regex = /^#\b[a-zA-Z0-9_]+\b$/;
+    var copy = {};
+    var ast = {};
+
+    //Evaluation if not a literal
+    if (valueExp !== "Literal") {
+        copy = evalPumaAst(valueExp).value;
+    }
+
+    if (regex.test(copy) && PUMA_FORCE_REWRITE) {
+        return pumaAst($(getElementById($valueExp)));
+    } else if (regex.test(valueExp.value)) {
+        valueExp.value = valueExp.value.substring(1);
+        return pumaAst($(getElementById($valueExp)));
+    }
+    return null;
+}
+
+// Tests
+
+//Add a class in runtime so it does not need to re-write
+var t = " .paco";
+
+//Context evaluation
+var a = function () {
+    var name = "puma";
+    $("#" + name + t);
+}();
+
+//Re-write because it returns a string
+var j = "ma";
+
+//Context evaluation
+var b = function () {
+    var name = "pu";
+    $("#" + name + j);
+}();


### PR DESCRIPTION
Adding grunt task source file and tests defined in previous repository.

Before publishing, `pumascript` npm module needs to be fixed: pointing to an existent entry point. See [this issue](https://github.com/pumascript/puma/issues/69) for details.